### PR TITLE
Compatibility with ggplot2 3.6.0

### DIFF
--- a/R/hello.R
+++ b/R/hello.R
@@ -1992,15 +1992,26 @@ plot_split_crd <- function(design, nrows, ncols,
 #' plot_split_crd(outdesign2,ncols = 6,nrows=5)+
 #' theme_pres()
 theme_pres <- function() {
-  theme(text = element_text(size = 16, colour = "black"),
-        axis.text = element_text(size = 18, colour = "black"),
-        axis.title = element_text(size = 18, colour = "black"),
-        axis.line = element_line(colour = "black",
-                                 size = 1, linetype = "solid"),
-        axis.ticks = element_line(colour = "black")) +
-    theme(plot.background = element_rect(fill = "white",
-                                         color = NA),
-          panel.background = element_rect(fill = "white",color = NA))
+  my_theme <- theme(text = element_text(size = 16, colour = "black"),
+                 axis.text = element_text(size = 18, colour = "black"),
+                 axis.title = element_text(size = 18, colour = "black"),
+                 axis.line = element_line(colour = "black",
+                                          linewidth = 1, linetype = "solid"),
+                 axis.ticks = element_line(colour = "black"),
+                 plot.background = element_rect(fill = "white",
+                                                color = NA),
+                 panel.background = element_rect(fill = "white",color = NA))
+
+  if (packageVersion("ggplot2") >= "3.4.0") {
+    my_theme <- my_theme +
+      theme(axis.line = element_line(colour = "black",
+                                     linewidth = 1, linetype = "solid"))
+  } else {
+    my_theme <- my_theme +
+      theme(axis.line = element_line(colour = "black",
+                                     size = 1, linetype = "solid"))
+  }
+  my_theme
 }
 
 
@@ -2022,15 +2033,24 @@ theme_pres <- function() {
 #' plot_split_crd(outdesign2,ncols = 6,nrows=5)+
 #' theme_poster()
 theme_poster <- function() {
-  theme(text = element_text(size = 24, colour = "black"),
+  my_theme <- theme(text = element_text(size = 24, colour = "black"),
         axis.text = element_text(size = 28, colour = "black"),
         axis.title = element_text(size = 28, colour = "black"),
-        axis.line = element_line(colour = "black",
-                                 size = 1, linetype = "solid"),
         axis.ticks = element_line(colour = "black")) +
     theme(plot.background = element_rect(fill = "white",
                                          color = NA),
           panel.background = element_rect(fill = "white", color = NA))
+
+  if (packageVersion("ggplot2") >= "3.4.0") {
+    my_theme <- my_theme +
+      theme(axis.line = element_line(colour = "black",
+                                     linewidth = 1, linetype = "solid"))
+  } else {
+    my_theme <- my_theme +
+      theme(axis.line = element_line(colour = "black",
+                                     size = 1, linetype = "solid"))
+  }
+  my_theme
 }
 
 

--- a/R/hello.R
+++ b/R/hello.R
@@ -276,11 +276,11 @@ plot_design.factorial_rcbd <- function(design,
         min(table$col)
     }
 
-    plt <- ggplot(table, aes_string(x = "col", y = y)) +
-      geom_tile(aes_string(fill = factor_name),
+    plt <- ggplot(table, aes(x = .data[["col"]], y = .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name]]),
                 width = width * space_width, height = height *
                   space_height) + theme_bw() + theme(line = element_blank()) +
-      geom_text(aes_string(label = "plots"),
+      geom_text(aes(label = .data[["plots"]]),
                 colour = "black")
 
     return(plt)
@@ -367,11 +367,11 @@ plot_design_crd <- function(design,
       table$col <- abs(table$col - max(table$col)) +
         min(table$col)
     }
-    plt <- ggplot(table, aes_string(x = "col", y)) +
-      geom_tile(aes_string(fill = factor_name),
+    plt <- ggplot(table, aes(x = .data$col, .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name]]),
                 width = width * space_width, height = height *
                   space_height) + theme_bw() + theme(line = element_blank()) +
-      geom_text(aes_string(label = labels), colour = "black")
+      geom_text(aes(label = .data[[labels]]), colour = "black")
 
     plt
 
@@ -461,11 +461,11 @@ plot_alpha <- function(design, x = "cols", y = "block",
       table[, y] <- abs(table[, y] - max(table[, y])) +
         min(table[, y])
     }
-    plt <- ggplot(table, aes_string(x, y)) +
-      geom_tile(aes_string(fill = factor_name),
+    plt <- ggplot(table, aes(.data[[x]], .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name]]),
                 width = width * space_width, height = height *
                   space_height) + theme_bw() + theme(line = element_blank())+
-      geom_text(aes_string(label = labels), colour = "black")
+      geom_text(aes(label = .data[[labels]]), colour = "black")
 
     plt
 
@@ -555,11 +555,11 @@ plot_lattice_triple <- function(design,
         min(table[, y])
     }
 
-    plt <- ggplot(table, aes_string(x = "part", y)) +
-      geom_tile(aes_string(fill = factor_name),
+    plt <- ggplot(table, aes(x = .data[["part"]], .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name]]),
                 width = width * space_width, height = height *
                   space_height) + theme_bw() + theme(line = element_blank())+
-      geom_text(aes_string(label = labels), colour = "black")
+      geom_text(aes(label = .data[[labels]]), colour = "black")
 
     plt
 
@@ -647,12 +647,12 @@ plot_lattice_simple <- function(design,
         min(table[, y])
     }
 
-    plt <- ggplot(table, aes_string(x = "part", y)) +
-      geom_tile(aes_string(fill = factor_name),
+    plt <- ggplot(table, aes(x = .data[["part"]], .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name]]),
           width = width * space_width, height = height *
           space_height) +
       theme_bw() + theme(line = element_blank()) +
-      geom_text(aes_string(label = labels), colour = "black")
+      geom_text(aes(label = .data[[labels]]), colour = "black")
 
     plt
 
@@ -736,11 +736,11 @@ plot_latin_square <- function(design,
       table[, x]  <- abs(table[, x]  - max(table[, x] )) +
         min(table[, x] )
     }
-    plt <- ggplot(table, aes_string(x = x, y = y)) +
-      geom_tile(aes_string(fill = factor_name),
+    plt <- ggplot(table, aes(x = .data[[x]], y = .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name]]),
                 width = width * space_width, height = height *
                   space_height) + theme_bw() + theme(line = element_blank()) +
-      geom_text(aes_string(label = labels), colour = "black")
+      geom_text(aes(label = .data[[labels]]), colour = "black")
 
     plt
 
@@ -827,12 +827,12 @@ plot_graeco <- function(design,
       table[, x]  <- abs(table[, x]  - max(table[, x] )) +
         min(table[, x] )
     }
-    plt <- ggplot(table, aes_string(x, y)) +
-      geom_tile(aes_string(fill = factor_name),
+    plt <- ggplot(table, aes(.data[[x]], .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name]]),
                 width = width * space_width,
                 height = height *space_height) +
       theme_bw() + theme(line = element_blank()) +
-      geom_text(aes_string(label = labels), colour = "black")
+      geom_text(aes(label = .data[[labels]]), colour = "black")
 
 
     return(plt)
@@ -940,11 +940,11 @@ plot_strip <- function(design,
       table[, x]  <- abs(table[, x]  - max(table[, x] )) +
         min(table[, x] )
     }
-    plt <- ggplot(table, aes_string(x = x, y = y)) +
-      geom_tile(aes_string(fill = factor_name_1),
+    plt <- ggplot(table, aes(x = .data[[x]], y = .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name_1]]),
                 width = width * space_width, height = height *
                   space_height) + theme_bw() + theme(line = element_blank()) +
-      geom_text(aes_string(label = labels), colour = "black")
+      geom_text(aes(label = .data[[labels]]), colour = "black")
 
 
     return(plt)
@@ -1031,11 +1031,11 @@ plot_bib <- function(design,
       table$col <- abs(table$col - max(table$col)) +
         min(table$col)
     }
-    plt <- ggplot(table, aes_string(x = "col", y = y)) +
-      geom_tile(aes_string(fill = factor_name),
+    plt <- ggplot(table, aes(x = .data[["col"]], y = .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name]]),
                 width = width * space_width, height = height *
                   space_height) + theme_bw() + theme(line = element_blank()) +
-      geom_text(aes_string(label = labels), colour = "black")
+      geom_text(aes(label = .data[[labels]]), colour = "black")
 
 
     return(plt)
@@ -1122,11 +1122,11 @@ plot_cyclic <- function(design,
       table$part <- abs(table$part - max(table$part)) +
         min(table$part)
     }
-    plt <- ggplot(table, aes_string(x = "part", y = y)) +
-      geom_tile(aes_string(fill = factor_name),
+    plt <- ggplot(table, aes(x = .data[["part"]], y = .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name]]),
                 width = width * space_width, height = height *
                   space_height) + theme_bw() + theme(line = element_blank()) +
-      geom_text(aes_string(label = labels), colour = "black")
+      geom_text(aes(label = .data[[labels]]), colour = "black")
 
 
     return(plt)
@@ -1219,11 +1219,11 @@ plot_dau <- function(design,
       table$col <- abs(table$col - max(table$col)) +
         min(table$col)
     }
-    plt <- ggplot(table, aes_string(x = "col", y = y)) +
-      geom_tile(aes_string(fill = factor_name),
+    plt <- ggplot(table, aes(x = .data[["col"]], y = .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name]]),
                 width = width * space_width, height = height *
                   space_height) + theme_bw() + theme(line = element_blank()) +
-      geom_text(aes_string(label = labels), colour = "black")
+      geom_text(aes(label = .data[[labels]]), colour = "black")
 
 
     return(plt)
@@ -1318,11 +1318,11 @@ plot_rcbd <- function(design,
     table[, y] <- as.numeric(table[, y]) * height
     table[, labels] <- str_wrap(table[,treatment_label], width = label_width)
 
-    plt <- ggplot(table, aes_string(x = "col", y = y)) +
-      geom_tile(aes_string(fill = factor_name),
+    plt <- ggplot(table, aes(x = .data[["col"]], y = .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name]]),
                 width = width * space_width, height = height *
                   space_height) + theme_bw() + theme(line = element_blank()) +
-      geom_label(aes_string(label = labels), colour = "black",fill= "white")
+      geom_label(aes(label = .data[[labels]]), colour = "black",fill= "white")
 
 
     return(plt)
@@ -1431,12 +1431,12 @@ plot_design.factorial_crd <- function(design,
       table$col <- abs(table$col - max(table$col)) +
         min(table$col)
     }
-    plt <- ggplot(table, aes_string(x = "col", y = y)) +
-      geom_tile(aes_string(fill = factor_name),
+    plt <- ggplot(table, aes(x = .data[["col"]], y = .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name]]),
                 width = width * space_width, height = height *
                   space_height) + theme_bw() +
       theme(line = element_blank()) +
-      geom_text(aes_string(label = labels),
+      geom_text(aes(label = .data[[labels]]),
                 colour = "black")
 
     return(plt)
@@ -1525,13 +1525,12 @@ plot_design.factorial_lsd <- function(design,
       table[, x]  <- abs(table[, x]  - max(table[, x] )) +
         min(table[, x] )
     }
-    plt <- ggplot(table, aes_string(x = x,
-                                                      y = y)) +
-      geom_tile(aes_string(fill = factor_name),
+    plt <- ggplot(table, aes(x = .data[[x]], y = .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name]]),
                   width = width * space_width, height = height *
               space_height) + theme_bw() +
       theme(line = element_blank()) +
-      geom_text(aes_string(label = labels),
+      geom_text(aes(label = .data[[labels]]),
                          colour = "black")
 
     plt
@@ -1649,11 +1648,11 @@ plot_split_rcbd <- function(design,
       divider <- length(unique(table[, factor_name_1]))
       table$sequence <- table$sequence/divider
 
-      plt2 <- ggplot(table, aes_string("sequence", y)) +
-        geom_tile(aes_string(fill = factor_name_2),
+      plt2 <- ggplot(table, aes(.data[["sequence"]], .data[[y]])) +
+        geom_tile(aes(fill = .data[[factor_name_2]]),
                   width = width/divider * space_width,
                   height = height * space_height) + theme_bw() +
-        theme(line = element_blank()) + geom_text(aes_string(label = labels),
+        theme(line = element_blank()) + geom_text(aes(label = .data[[labels]]),
                                                   colour = "black")
 
 
@@ -1661,11 +1660,11 @@ plot_split_rcbd <- function(design,
 
     } else{
 
-      plt <- ggplot(table, aes_string("row", y)) +
-        geom_tile(aes_string(fill = factor_name_1),
+      plt <- ggplot(table, aes(.data[["row"]], .data[[y]])) +
+        geom_tile(aes(fill = .data[[factor_name_1]]),
         width = width * space_width, height = height * space_height) +
         theme_bw() + theme(line = element_blank()) +
-        geom_text(aes_string(label = labels), colour = "black")
+        geom_text(aes(label = .data[[labels]]), colour = "black")
       return(plt)
     }
 
@@ -1774,22 +1773,22 @@ plot_split_lsd <- function(design,
     divider <- length(unique(table[, factor_name_1]))
     table$sequence <- table$sequence/divider
 
-    plt2 <- ggplot(table, aes_string("sequence", "row")) +
-      geom_tile(aes_string(fill = factor_name_2),
+    plt2 <- ggplot(table, aes(.data[["sequence"]], .data[["row"]])) +
+      geom_tile(aes(fill = .data[[factor_name_2]]),
                 width = width/divider * space_width,
                 height = height * space_height) + theme_bw() +
       theme(line = element_blank()) +
-      geom_text(aes_string(label = labels),colour = "black")
+      geom_text(aes(label = .data[[labels]]),colour = "black")
 
 
     return(plt2)
     } else {
-      plt <- ggplot(table, aes_string("col", "row")) +
-        geom_tile(aes_string(fill = factor_name_1),
+      plt <- ggplot(table, aes(.data[["col"]], .data[["row"]])) +
+        geom_tile(aes(fill = .data[[factor_name_1]]),
                   width = width * space_width, height = height *
                     space_height) + theme_bw() +
         theme(line = element_blank()) +
-        geom_text(aes_string(label = labels),
+        geom_text(aes(label = .data[[labels]]),
                   colour = "black")
 
       return(plt)
@@ -1936,22 +1935,22 @@ plot_split_crd <- function(design, nrows, ncols,
       divider <- length(unique(table[, factor_name_1]))
       table$sequence <- table$sequence/divider
 
-      plt2 <- ggplot(table, aes_string("sequence", "row")) +
-        geom_tile(aes_string(fill = factor_name_2),
+      plt2 <- ggplot(table, aes(.data[["sequence"]], .data[["row"]])) +
+        geom_tile(aes(fill = .data[[factor_name_2]]),
                   width = width * space_width/divider,
                   height = height * space_height) +
         theme_bw() + theme(line = element_blank()) +
-        geom_text(aes_string(label = labels),
+        geom_text(aes(label = .data[[labels]]),
                   colour = "black")
 
       return(plt2)
       } else {
-        plt <- ggplot(table, aes_string("col", "row")) +
-          geom_tile(aes_string(fill = factor_name_1),
+        plt <- ggplot(table, aes(.data[["col"]], .data[["row"]])) +
+          geom_tile(aes(fill = .data[[factor_name_1]]),
                     width = width * space_width, height = height *
                       space_height) + theme_bw() +
           theme(line = element_blank()) +
-          geom_text(aes_string(label = labels),
+          geom_text(aes(label = .data[[labels]]),
                     colour = "black")
 
         return(plt)
@@ -2097,11 +2096,11 @@ plot_youden <- function(design, x = "col", y = "row",
     }
 
 
-    plt <- ggplot(table, aes_string(x = x, y = y)) +
-      geom_tile(aes_string(fill = factor_name),
+    plt <- ggplot(table, aes(x = .data[[x]], y = .data[[y]])) +
+      geom_tile(aes(fill = .data[[factor_name]]),
                 width = width * space_width, height = height *
                   space_height) + theme_bw() + theme(line = element_blank()) +
-      geom_text(aes_string(label = labels), colour = "black")
+      geom_text(aes(label = .data[[labels]]), colour = "black")
 
 
     return(plt)
@@ -2884,11 +2883,11 @@ full_control_positions <- function(design,
     table[, x]  <- abs(table[, x]  - max(table[, x] )) +
       min(table[, x] )
   }
-  plt <- ggplot(table, aes_string(x = x, y = y)) +
-    geom_tile(aes_string(fill = factor_name),
+  plt <- ggplot(table, aes(x = .data[[x]], y = .data[[y]])) +
+    geom_tile(aes(fill = .data[[factor_name]]),
               width = width * space_width, height = height *
                 space_height) + theme_bw() + theme(line = element_blank()) +
-    geom_text(aes_string(label = labels), colour = "black")
+    geom_text(aes(label = .data[[labels]]), colour = "black")
 
   plt
 

--- a/tests/testthat/testall.R
+++ b/tests/testthat/testall.R
@@ -1,3 +1,8 @@
+get_labs <- function(x) x$labels
+if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+  get_labs <- ggplot2::get_labs
+}
+
 test_that("throws error if data type is not an integer but a string", {
   expect_error(test_input_extend("3"))
 })
@@ -415,7 +420,7 @@ test_that("plot a ggplot alpha design", {
   outdesign <- design.alpha(trt, k, r, serie = 2)
   p <- plot_alpha(outdesign, reverse_y = TRUE,
                   reverse_x = TRUE)
-  expect_identical(p$labels$y, "block")
+  expect_identical(get_labs(p)$y, "block")
 })
 
 
@@ -427,7 +432,7 @@ test_that("plot a ggplot bib", {
   p <- plot_bib(outdesign, reverse_y = TRUE,
                 reverse_x = TRUE, y="block")
   p
-  expect_identical(p$labels$y, "block")
+  expect_identical(get_labs(p)$y, "block")
 })
 
 
@@ -445,7 +450,7 @@ test_that("plot a ggplot cyclic",
                              factor_name = "trt",
                              reverse_y = TRUE, reverse_x = TRUE)
             p
-            expect_identical(p$labels$y,
+            expect_identical(get_labs(p)$y,
                              "block")
           })
 
@@ -456,7 +461,7 @@ test_that("plot a ggplot dau design", {
   p <- plot_dau(outdesign, reverse_y = TRUE,
                 reverse_x = TRUE)
   p
-  expect_identical(p$labels$y, "block")
+  expect_identical(get_labs(p)$y, "block")
 })
 
 test_that("plot a factorial crd design", {
@@ -466,7 +471,7 @@ test_that("plot a factorial crd design", {
   p <- plot_design.factorial_crd(outdesign, ncols = 5,
                                  nrows = 6, reverse_y = TRUE, reverse_x = TRUE)
   p
-  expect_identical(p$labels$y, "row")
+  expect_identical(get_labs(p)$y, "row")
 })
 
 test_that("plot a factorial lsd design", {
@@ -475,7 +480,7 @@ test_that("plot a factorial lsd design", {
                          design = "lsd")
   p <- plot_design.factorial_lsd(outdesign,
                                  reverse_y = TRUE, reverse_x = TRUE)
-  expect_identical(p$labels$y, "row")
+  expect_identical(get_labs(p)$y, "row")
 })
 
 test_that("plot a factorial rcbd design", {
@@ -485,7 +490,7 @@ test_that("plot a factorial rcbd design", {
                          design = "rcbd")
   p <- plot_design.factorial_rcbd(outdesign,
                                   reverse_y = TRUE, reverse_x = TRUE)
-  expect_identical(p$labels$y, "row")
+  expect_identical(get_labs(p)$y, "row")
 })
 
 test_that("plot error due to low nrow number factorial crd",
@@ -519,7 +524,7 @@ test_that("plot a youden design", {
                              seed = 23)
   p <- plot_youden(outdesign, labels = "varieties",
                    reverse_y = TRUE, reverse_x = TRUE)
-  expect_identical(p$labels$y, "row")
+  expect_identical(get_labs(p)$y, "row")
 })
 
 test_that("plot a strip design", {
@@ -532,7 +537,7 @@ test_that("plot a strip design", {
   p <- plot_strip(outdesign, factor_name_1 = "T1",factor_name_2="T2",
                   reverse_y = TRUE, reverse_x = TRUE)
   p
-  expect_identical(p$labels$y, "row")
+  expect_identical(get_labs(p)$y, "row")
 })
 
 test_that("plot a rcbd design", {
@@ -542,7 +547,7 @@ test_that("plot a rcbd design", {
   p <- plot_rcbd(outdesign, reverse_y = TRUE,
                  reverse_x = TRUE)
   p
-  expect_identical(p$labels$y, "block")
+  expect_identical(get_labs(p)$y, "block")
 })
 
 
@@ -553,7 +558,7 @@ test_that("plot a crd design", {
   p <- plot_design_crd(outdesign1, ncols = 13, nrows = 3,
                        reverse_y = TRUE, reverse_x = TRUE)
   p
-  expect_identical(p$labels$y, "row")
+  expect_identical(get_labs(p)$y, "row")
 })
 
 test_that("plot a graeco design", {
@@ -565,7 +570,7 @@ test_that("plot a graeco design", {
   p <- plot_graeco(outdesign, factor_name = "T2",
                    reverse_y = TRUE, reverse_x = TRUE)
   p
-  expect_identical(p$labels$y, "row")
+  expect_identical(get_labs(p)$y, "row")
 })
 
 
@@ -576,7 +581,7 @@ test_that("plot a lattice triple design", {
                            reverse_x = TRUE, reverse_y = TRUE)
 
 
-  expect_identical(p$labels$y, "block")
+  expect_identical(get_labs(p)$y, "block")
 })
 
 
@@ -586,7 +591,7 @@ test_that("plot a lattice simple design", {
   p <- plot_lattice_simple(outdesign, width = 2,
     height = 1, reverse_y = TRUE, reverse_x = TRUE)
 
-  expect_identical(p$labels$y, "block")
+  expect_identical(get_labs(p)$y, "block")
 })
 
 test_that("plot a latin square design", {
@@ -595,7 +600,7 @@ test_that("plot a latin square design", {
   p <- plot_latin_square(outdesign, reverse_y = TRUE,
                          reverse_x = TRUE)
 
-  expect_identical(p$labels$y, "row")
+  expect_identical(get_labs(p)$y, "row")
 })
 
 
@@ -605,7 +610,7 @@ test_that("plot a latin square design", {
   p <- plot_latin_square(outdesign, reverse_y = TRUE,
                          reverse_x = TRUE)
 
-  expect_identical(p$labels$y, "row")
+  expect_identical(get_labs(p)$y, "row")
 })
 
 test_that("plot a latin square design theme_pres", {
@@ -614,7 +619,7 @@ test_that("plot a latin square design theme_pres", {
   p <- plot_latin_square(outdesign, reverse_y = TRUE,
                          reverse_x = TRUE)
   p <- p + theme_pres()
-  expect_identical(p$labels$y, "row")
+  expect_identical(get_labs(p)$y, "row")
 })
 test_that("plot a latin square design theme_poster",
           {
@@ -625,7 +630,7 @@ test_that("plot a latin square design theme_poster",
                                    reverse_x = TRUE)
             p <- p + theme_poster()
             p
-            expect_identical(p$labels$y, "row")
+            expect_identical(get_labs(p)$y, "row")
           })
 
 
@@ -640,7 +645,7 @@ test_that("plot a split plot design crd  for subplots", {
                       reverse_y = TRUE, reverse_x = TRUE,subplots = TRUE)
   p <- p + theme_poster()
   p
-  expect_identical(p$labels$y, "row")
+  expect_identical(get_labs(p)$y, "row")
 })
 
 test_that("plot a split plot design rcbd  for subplots", {
@@ -655,7 +660,7 @@ test_that("plot a split plot design rcbd  for subplots", {
                        factor_name_2 = "t2")
   p <- p + theme_poster()
 
-  expect_identical(p$labels$y, "block")
+  expect_identical(get_labs(p)$y, "block")
 })
 
 test_that("plot a split plot design lsd for subplots", {
@@ -667,7 +672,7 @@ test_that("plot a split plot design lsd for subplots", {
   p <- plot_split_lsd(outdesign2, width = 4, height = 4,
                       reverse_y = TRUE, reverse_x = TRUE)
   p
-  expect_identical(p$labels$y, "row")
+  expect_identical(get_labs(p)$y, "row")
 })
 
 
@@ -683,7 +688,7 @@ test_that("plot a split plot design crd for main plots", {
                       reverse_y = TRUE, reverse_x = TRUE,  subplots = FALSE)
   p <- p + theme_poster()
   p
-  expect_identical(p$labels$y, "row")
+  expect_identical(get_labs(p)$y, "row")
 })
 
 test_that("plot a split plot design rcbd for main plots", {
@@ -700,7 +705,7 @@ test_that("plot a split plot design rcbd for main plots", {
                        subplots = FALSE, factor_name_1 = "t1",
                        factor_name_2 = "t2")
   p
-  expect_identical(p$labels$y, "block")
+  expect_identical(get_labs(p)$y, "block")
 })
 
 
@@ -714,7 +719,7 @@ test_that("plot a split plot design lsd for main plots", {
   p <- plot_split_lsd(outdesign2, width = 4, height = 4,
                       reverse_y = TRUE, reverse_x = TRUE, subplots = FALSE)
   p
-  expect_identical(p$labels$y, "row")
+  expect_identical(get_labs(p)$y, "row")
 })
 
 test_that("plot a split plot design lsd for main plots", {
@@ -723,7 +728,7 @@ outdesign<-design.lattice(trt,r=3,serie=2)
 p <- plot_lattice_triple(outdesign)
 
 p
-expect_identical(p$labels$y, "block")
+expect_identical(get_labs(p)$y, "block")
 
 })
 
@@ -734,7 +739,7 @@ test_that("plot a split plot design lsd for main plots", {
   p <- plot_lattice_triple(outdesign)
 
   p
-  expect_identical(p$labels$y, "block")
+  expect_identical(get_labs(p)$y, "block")
 
 })
 
@@ -744,7 +749,7 @@ test_that("plot a split plot design lsd for main plots", {
   p <- plot_lattice_triple(outdesign)
 
   p
-  expect_identical(p$labels$y, "block")
+  expect_identical(get_labs(p)$y, "block")
 
 })
 
@@ -754,7 +759,7 @@ test_that("plot a split plot design lsd for main plots", {
   p <- plot_lattice_triple(outdesign)
 
   p
-  expect_identical(p$labels$y, "block")
+  expect_identical(get_labs(p)$y, "block")
 
 })
 
@@ -822,7 +827,7 @@ width = 12,
 height = 10,
 reverse_y = TRUE,
 reverse_x = TRUE)
-  expect_identical(p$labels$y, "ROW")
+  expect_identical(get_labs(p)$y, "ROW")
 
 })
 
@@ -844,6 +849,6 @@ test_that("plot a plot design from FielDHub package shows COLUMN as x axis", {
                      reverse_x = TRUE)
 
 
-  expect_identical(p$labels$x, "COLUMN")
+  expect_identical(get_labs(p)$x, "COLUMN")
 
 })


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the agricolaeplotr package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
In addition, some deprecated functionality is avoided.
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun